### PR TITLE
fix: update copyright year 2023-2026 BJUT-SWIFT

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,4 +56,4 @@ hooks:
   - hooks/contributors.py
 
 copyright: |
-  &copy; 2024 <a href="https://github.com/bjut-swift"  target="_blank" rel="noopener">BJUT-SWIFT</a>
+  &copy; 2023-2026 <a href="https://github.com/bjut-swift"  target="_blank" rel="noopener">BJUT-SWIFT</a>


### PR DESCRIPTION
修改文件：mkdocs.yml
修改内容：将版权年份从 2024 改为 2023-2026